### PR TITLE
README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ users through your app.
 
 `ember install ember-introjs`
 
-`bower install`
+`bower install intro.js --save`
 
 ## Usage
 


### PR DESCRIPTION
Fixed README reference to bower install. It was missing the package name and --save option.