### PR TITLE
Feature step component

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ users through your app.
 
 ## Usage
 
-To declare your steps, you need to declare an array in JavaScript in
-your controller or parent component:
+### 1. Declare your steps:
+- You can declare an array in JavaScript in your controller or parent component:
 
 ```javascript
 // app/controllers/ticket.js
@@ -35,7 +35,25 @@ export default Ember.Controller.extend({
   })
 });
 ```
+#### 2. Use `intro-js/step` component as a wrapper
 
+```hbs
+{{#intro-js/step step=1 intro="Step Component"}}
+  <h1>Hello!</h1>
+{{/intro-js/step}}
+```
+You can customize wrapper using:
+- `position="top"`
+- `intro="Welcome!"`
+- `tooltipClass="tooltip-class"`
+- `highlightClass="highlight-class"`
+- `position="top"`
+- `hint="Use it :)"`
+- `hintPosition="bottom-left"`
+
+Options are documented in the code as well as in [IntroJS Docs](http://introjs.com/docs)
+
+### 2. User `intro-js` component
 Then to use the steps, you can use the steps in your handlebars
 template:
 

--- a/addon/components/step.js
+++ b/addon/components/step.js
@@ -1,0 +1,54 @@
+import Ember from 'ember';
+
+const { Component, computed } = Ember;
+
+export default Component.extend({
+  // Optionally define the number (priority) of step
+  step: 0,
+
+  // The tooltip text of step
+  intro: null,
+
+  // Optionally define a CSS class for tooltip
+  tooltipClass: null,
+
+  // Optionally append a CSS class to the helperLayer
+  highlightClass: null,
+
+  // Optionally define the position of tooltip, top, left, right,
+  // bottom, bottom-left-aligned (same as bottom), bottom-middle-aligned,
+  // bottom-right-aligned or auto (to detect the position of element
+  // and assign the correct position automatically). Default is bottom
+  position: 'bottom',
+
+  // The tooltip text of hint
+  hint: null,
+
+  // Optionally define the position of hint. Options: top-middle, top-left,
+  // top-right, bottom-left, bottom-right, bottom-middle,
+  // middle-left, middle-right, middle-middle. Default: top-middle
+  hintPosition: 'top-middle',
+
+  // PRIVATE interface - INTRO JS implementation
+
+  attributeBindings: [
+    'data-step',
+    'data-intro',
+    'data-position',
+    'data-tooltipClass',
+    'data-highlightClass',
+    'data-hint',
+    'data-hintPosition'
+  ],
+
+  'data-step': computed.readOnly('step'),
+
+  'data-hint': computed.readOnly('hint'),
+  'data-intro': computed.readOnly('intro'),
+
+  'data-tooltipClass': computed.readOnly('tooltipClass'),
+  'data-highlightClass': computed.readOnly('highlightClass'),
+
+  'data-position': computed.readOnly('position'),
+  'data-hintPosition': computed.readOnly('hintPosition'),
+});

--- a/app/components/intro-js/step.js
+++ b/app/components/intro-js/step.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-introjs/components/step';

--- a/tests/integration/components/step-test.js
+++ b/tests/integration/components/step-test.js
@@ -1,0 +1,88 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupComponentTest } from 'ember-mocha';
+
+describe('Integration | Component | Step', function() {
+  setupComponentTest('intro-js/step');
+
+  describe('step', function() {
+    it('does render with 0 as default', function(){
+      this.render();
+
+      expect(this.$().attr('data-step')).to.equal('0');
+    });
+
+    it('does render with a custom value', function(){
+      this.subject({ step: 4 });
+      this.render();
+
+      expect(this.$().attr('data-step')).to.equal('4');
+    });
+  });
+
+  describe('intro', function() {
+    it('does render with a custom value', function(){
+      this.subject({ intro: 'My text' });
+      this.render();
+
+      expect(this.$().attr('data-intro')).to.equal('My text');
+    });
+  });
+
+  describe('tooltipClass', function() {
+    it('does render with a custom value', function(){
+      this.subject({ tooltipClass: 'my-class' });
+      this.render();
+
+      expect(this.$().attr('data-tooltipClass')).to.equal('my-class');
+    });
+  });
+
+  describe('highlightClass', function() {
+    it('does render with a custom value', function(){
+      this.subject({ highlightClass: 'my-class' });
+      this.render();
+
+      expect(this.$().attr('data-highlightClass')).to.equal('my-class');
+    });
+  });
+
+  describe('position', function() {
+    it('does render with bottom as default', function(){
+      this.render();
+
+      expect(this.$().attr('data-position')).to.equal('bottom');
+    });
+
+    it('does render with a custom value', function(){
+      this.subject({ position: 'top' });
+      this.render();
+
+      expect(this.$().attr('data-position')).to.equal('top');
+    });
+  });
+
+  describe('hint', function() {
+    it('does render with a custom value', function(){
+      this.subject({ hint: 'My text' });
+      this.render();
+
+      expect(this.$().attr('data-hint')).to.equal('My text');
+    });
+  });
+
+  describe('hintPosition', function() {
+    it('does render with top-middle as default', function(){
+      this.render();
+
+      expect(this.$().attr('data-hintPosition')).to.equal('top-middle');
+    });
+
+    it('does render with a custom value', function(){
+      this.subject({ hintPosition: 'top' });
+      this.render();
+
+      expect(this.$().attr('data-hintPosition')).to.equal('top');
+    });
+  });
+});


### PR DESCRIPTION
This PR will add a wrapper for using `step` as a component. More info and usage in the readme.
___
#### 2. Use `intro-js/step` component as a wrapper

```hbs
{{#intro-js/step step=1 intro="Step Component"}}
  <h1>Hello!</h1>
{{/intro-js/step}}
```
You can customize wrapper using:
- `position="top"`
- `intro="Welcome!"`
- `tooltipClass="tooltip-class"`
- `highlightClass="highlight-class"`
- `position="top"`
- `hint="Use it :)"`
- `hintPosition="bottom-left"`

Options are documented in the code as well as in [IntroJS Docs](http://introjs.com/docs)