### PR TITLE
Only merge tree if present in treeForVendor

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,13 +24,11 @@ module.exports = {
   },
 
   treeForVendor(tree) {
-    let trees = [tree];
-
-    trees.push(new Funnel(this.introJsPath(), {
+    const introJsTree = new Funnel(this.introJsPath(), {
       destDir: 'ember-introjs',
       files: ['intro.js', 'introjs.css']
-    }));
+    });
 
-    return mergeTrees(trees);
+    return tree ? new mergeTrees([tree, introJsTree]) : introJsTree;
   },
 };


### PR DESCRIPTION
Using `ember-introjs` in Ember CLI 2.18.1, I get the error: `BroccoliMergeTrees: Expected Broccoli node, got undefined for inputNodes[0]`. I try to solve it.

Similar issue here: martndemus/ember-font-awesome#120